### PR TITLE
Allow optionally-defined BepInPlugin to support library usage

### DIFF
--- a/LethalCompanyInputUtils/Api/LcInputActions.cs
+++ b/LethalCompanyInputUtils/Api/LcInputActions.cs
@@ -35,10 +35,10 @@ public abstract class LcInputActions
 
     protected virtual string MapName => GetType().Name;
 
-    protected LcInputActions()
+    protected LcInputActions(BepInPlugin? plugin = null)
     {
         Asset = ScriptableObject.CreateInstance<InputActionAsset>();
-        Plugin = Assembly.GetCallingAssembly().GetBepInPlugin() ?? throw new InvalidOperationException();
+        Plugin = plugin ?? Assembly.GetCallingAssembly().GetBepInPlugin() ?? throw new InvalidOperationException();
 
         var mapBuilder = new InputActionMapBuilder(Id);
 


### PR DESCRIPTION
For 99% of use-cases, `LcInputActions` as it is now works fine. However, if you're developing a library that interfaces with it and want to wrap around it, the check for the plugin from the calling assembly will always return the library, which obviously causes a problem.

This modification is simple, won't break existing usages, and allows you to optionally define which Plugin owns the LcInputActions implementation.