### PR TITLE
Revert "Allow optionally-defined BepInPlugin to support library usage"

### DIFF
--- a/LethalCompanyInputUtils/Api/LcInputActions.cs
+++ b/LethalCompanyInputUtils/Api/LcInputActions.cs
@@ -35,10 +35,10 @@ public abstract class LcInputActions
 
     protected virtual string MapName => GetType().Name;
 
-    protected LcInputActions(BepInPlugin? plugin = null)
+    protected LcInputActions()
     {
         Asset = ScriptableObject.CreateInstance<InputActionAsset>();
-        Plugin = plugin ?? Assembly.GetCallingAssembly().GetBepInPlugin() ?? throw new InvalidOperationException();
+        Plugin = Assembly.GetCallingAssembly().GetBepInPlugin() ?? throw new InvalidOperationException();
 
         var mapBuilder = new InputActionMapBuilder(Id);
 


### PR DESCRIPTION
Reverts Rune580/LethalCompanyInputUtils#43

The PR in question breaks compatibility with existing dependent mods.