### PR TITLE
Allow optionally-defined BepInPlugin to support library usage (again)

### DIFF
--- a/LethalCompanyInputUtils/Api/LcInputActions.cs
+++ b/LethalCompanyInputUtils/Api/LcInputActions.cs
@@ -35,10 +35,12 @@ public abstract class LcInputActions
 
     protected virtual string MapName => GetType().Name;
 
-    protected LcInputActions()
+    protected LcInputActions() : this(Assembly.GetCallingAssembly().GetBepInPlugin()) {}
+
+    protected LcInputActions(BepInPlugin? plugin)
     {
         Asset = ScriptableObject.CreateInstance<InputActionAsset>();
-        Plugin = Assembly.GetCallingAssembly().GetBepInPlugin() ?? throw new InvalidOperationException();
+        Plugin = plugin ?? throw new InvalidOperationException();
 
         var mapBuilder = new InputActionMapBuilder(Id);
 


### PR DESCRIPTION
I'm not entirely certain what broke, last time. It seemed to be okay for me in testing, but maybe I was just dumb.

I can't think of a single reason that _this_ version would break existing implementations, however.