### PR TITLE
Prevent InputUtils from loading before Unity is loaded

### DIFF
--- a/LethalCompanyInputUtils/Api/LcInputActions.cs
+++ b/LethalCompanyInputUtils/Api/LcInputActions.cs
@@ -76,7 +76,7 @@ public abstract class LcInputActions
             _inputProps[prop] = attr;
         }
 
-        LcInputActionApi.RegisterInputActions(this, mapBuilder);
+        LcInputActionApi.QueueInputActionRegistration(this, mapBuilder);
     }
 
     public virtual void CreateInputActions(in InputActionMapBuilder builder) { }

--- a/LethalCompanyInputUtils/LethalCompanyInputUtilsPlugin.cs
+++ b/LethalCompanyInputUtils/LethalCompanyInputUtilsPlugin.cs
@@ -41,9 +41,9 @@ public class LethalCompanyInputUtilsPlugin : BaseUnityPlugin
         
         ModCompat.Init(this);
         
+        SceneManager.activeSceneChanged += OnUnityLoaded;
+
         Logging.Info($"InputUtils {PluginInfo.PLUGIN_VERSION} has finished loading!");
-        
-        SceneManager.activeSceneChanged += TryExportLayoutsOnLoad;
     }
 
     private static void LoadAssetBundles()
@@ -107,10 +107,11 @@ public class LethalCompanyInputUtilsPlugin : BaseUnityPlugin
         Logging.Info("Registered InputUtilsExtendedMouse Layout Override!");
     }
     
-    private static void TryExportLayoutsOnLoad(Scene arg0, Scene arg1)
+    private static void OnUnityLoaded(Scene arg0, Scene arg1)
     {
-        SceneManager.activeSceneChanged -= TryExportLayoutsOnLoad;
+        SceneManager.activeSceneChanged -= OnUnityLoaded;
         
+        LcInputActionApi.Initialize();
         LayoutExporter.TryExportLayouts();
     }
 }


### PR DESCRIPTION
Mostly applies to slower system as InputUtils was registering InputAction as soon as it could. On systems fast enough it had no issues, but on slower systems InputUtils was trying to register before Unity had finished loading. This PR should rectify that.